### PR TITLE
Fixing inference in match expressions

### DIFF
--- a/src/Saga/Language/Typechecker/Environment.hs
+++ b/src/Saga/Language/Typechecker/Environment.hs
@@ -25,7 +25,6 @@ data CompilerState = Saga
   , kinds       :: Map.Map String (Polymorphic Kind)
 , dataTypes   :: Map.Map String DataType
   , tags        :: [Tag]
-  , assumptions :: [Assumption]
   } deriving (Show)
 
 

--- a/src/Saga/Language/Typechecker/Inference/Inference.hs
+++ b/src/Saga/Language/Typechecker/Inference/Inference.hs
@@ -54,7 +54,6 @@ class Instantiate t where
 -- QUESTION: Is this the right place to define Generalization? It should now happen only after zonking, so there's no need for Inference to depend on it.
 class Generalize t where
     -- ENHANCEMENT: Define the needed effects as an associated type
-    type family Counter t :: *
     generalize :: (Eff.State Int :> es)  => t -> Eff es (Polymorphic t)
 
 

--- a/src/Saga/Language/Typechecker/Inference/Kind.hs
+++ b/src/Saga/Language/Typechecker/Inference/Kind.hs
@@ -150,7 +150,6 @@ instance Instantiate Kind  where
       qt' = apply sub qt
 
 instance Generalize Kind where
-    type Counter Kind = ()
     generalize k = return $ Forall (Set.toList $ ftv k) (Q.none :=> k)
 
 class HasKind t where

--- a/src/Saga/Language/Typechecker/Inference/Type/Expr.hs
+++ b/src/Saga/Language/Typechecker/Inference/Type/Expr.hs
@@ -269,7 +269,7 @@ infer' e = case e of
               (inferred, constraint) <- Eff.listen @Constraint $ infer expr
               ev <- Shared.mkEvidence
               -- QUESTION: Perhaps we should add another type of constraint here, to specifically prove a refinement rather than relying on equality
-              Eff.tell $ CST.Implication tvars [assume ev scrutineeType patTy] constraint
+              Eff.tell $ CST.Implication tvars [assume ev patTy scrutineeType] constraint
 
               return $ TypedCase pat patTy inferred
             where

--- a/src/Saga/Language/Typechecker/Inference/Type/Generalization.hs
+++ b/src/Saga/Language/Typechecker/Inference/Type/Generalization.hs
@@ -25,9 +25,6 @@ import           Saga.Language.Typechecker.Type                  (Scheme (..),
 import qualified Saga.Language.Typechecker.Variables             as Var
 
 instance Generalize Type where
-  -- TODO This can probably be simplified, we probably don't need the full Shared.State
-  type Counter Type = Shared.State
-
   generalize (T.Tuple tys) = do
     ts <- mapM generalize tys
     let (bs, cs, tvars, ts') = foldl accumulate (Map.empty, [], [], []) ts

--- a/src/Saga/Language/Typechecker/Inference/Type/Shared.hs
+++ b/src/Saga/Language/Typechecker/Inference/Type/Shared.hs
@@ -36,11 +36,12 @@ data State = IST
   { tvars  :: Int
   , evars  :: Int
   , levels :: Map.Map (Variable Type) Var.Level
+  , proofs :: Map.Map Type Type
   } deriving (Show)
 
 
 initialState :: State
-initialState = IST 0 0 Map.empty
+initialState = IST 0 0 Map.empty Map.empty
 
 
 fresh :: (Eff.Reader Var.Level :> es, Eff.State State :> es) => Eff es § Variable Type

--- a/src/Saga/Language/Typechecker/Lib.hs
+++ b/src/Saga/Language/Typechecker/Lib.hs
@@ -213,7 +213,6 @@ defaultEnv = Saga
   , kinds = Map.empty
   , dataTypes = Map.empty
   , tags = []
-  , assumptions = []
   , protocols =
       [ eqProtocol, numProtocol, isStringProtocol
       , functorProtocol, semigroupProtocol

--- a/src/Saga/Language/Typechecker/Run.hs
+++ b/src/Saga/Language/Typechecker/Run.hs
@@ -80,6 +80,7 @@ op x = E.FnApp (E.Identifier "/") [E.Literal $ LInt 1, x]
 
 cases = E.Lambda ["x"] $
         E.Match (E.Identifier "x")
-            [ E.Case (E.Lit $ LInt 1) (op $ E.Identifier "x")
-            , E.Case (E.Lit $ LString "Hello") (E.Identifier "x")
+            [ E.Case (E.Lit $ LInt 1) (E.Identifier "x")
+            -- , E.Case (E.Lit $ LString "Hello") (E.Literal $ LString "Return")
             ]
+

--- a/src/Saga/Language/Typechecker/Run.hs
+++ b/src/Saga/Language/Typechecker/Run.hs
@@ -8,7 +8,8 @@ import           Saga.Language.Typechecker.Inference.Inference           (Infere
 import           Saga.Language.Typechecker.Inference.Type.Generalization
 import           Saga.Language.Typechecker.Inference.Type.Instantiation
 
-import           Debug.Pretty.Simple                                     (pTraceM)
+import           Debug.Pretty.Simple                                     (pTrace,
+                                                                          pTraceM)
 import           Effectful                                               (Eff)
 import qualified Effectful                                               as Eff
 import qualified Effectful.Error.Static                                  as Eff
@@ -47,6 +48,7 @@ import           Saga.Utils.TypeLevel                                    (type (
 typecheck :: TypeCheck es => Expr -> Eff es (Expr, Polymorphic Type)
 typecheck expr  = do
     ((ast, st), constraint) <- Eff.runWriter @CST.Constraint . Eff.runState TI.initialState . Eff.runReader (Var.Level 0) $ infer expr
+    pTraceM $ "\nAST:\n" ++ show ast
     context <- Eff.inject $ Solver.run (constraint, levels st)
     (ast', ty) <- Zonking.run ast context
 
@@ -81,6 +83,6 @@ op x = E.FnApp (E.Identifier "/") [E.Literal $ LInt 1, x]
 cases = E.Lambda ["x"] $
         E.Match (E.Identifier "x")
             [ E.Case (E.Lit $ LInt 1) (E.Identifier "x")
-            -- , E.Case (E.Lit $ LString "Hello") (E.Literal $ LString "Return")
+            , E.Case (E.Lit $ LString "Hello") (E.Literal $ LString "World")
             ]
 

--- a/src/Saga/Language/Typechecker/Run.hs
+++ b/src/Saga/Language/Typechecker/Run.hs
@@ -47,8 +47,6 @@ import           Saga.Utils.TypeLevel                                    (type (
 typecheck :: TypeCheck es => Expr -> Eff es (Expr, Polymorphic Type)
 typecheck expr  = do
     ((ast, st), constraint) <- Eff.runWriter @CST.Constraint . Eff.runState TI.initialState . Eff.runReader (Var.Level 0) $ infer expr
-    pTraceM $ "AST:\n" ++ show ast
-    pTraceM $ "State:\n" ++ show st
     context <- Eff.inject $ Solver.run (constraint, levels st)
     (ast', ty) <- Zonking.run ast context
 
@@ -80,7 +78,8 @@ lte x y = E.FnApp (E.Identifier "<=") [x, y]
 
 op x = E.FnApp (E.Identifier "/") [E.Literal $ LInt 1, x]
 
-fn = E.Lambda ["x"] $
+cases = E.Lambda ["x"] $
         E.Match (E.Identifier "x")
             [ E.Case (E.Lit $ LInt 1) (op $ E.Identifier "x")
+            , E.Case (E.Lit $ LString "Hello") (E.Identifier "x")
             ]

--- a/src/Saga/Language/Typechecker/Solver/Constraints.hs
+++ b/src/Saga/Language/Typechecker/Solver/Constraints.hs
@@ -37,7 +37,7 @@ data Constraint where
     Impl        :: Variable Evidence -> Item -> ProtocolID -> Constraint
     OneOf       :: Item -> Item -> Constraint
     Refined     :: Scope -> Item -> Liquid -> Constraint
-    --Proof       :: Item -> Literal -> Constraint
+    Proof       :: Item -> Type -> Constraint
     Resource    :: Item -> Multiplicity -> Constraint
     Consumed    :: Item -> Constraint
     Pure        :: Item -> Constraint

--- a/src/Saga/Language/Typechecker/Solver/Refinements.hs
+++ b/src/Saga/Language/Typechecker/Solver/Refinements.hs
@@ -23,7 +23,6 @@ import qualified Effectful                                     as Eff
 import qualified Effectful.Error.Static                        as Eff
 import qualified Effectful.State.Static.Local                  as Eff
 import           Saga.Language.Core.Literals                   (Literal (LBool, LInt))
-import           Saga.Language.Typechecker.Environment         (CompilerState (assumptions))
 import           Saga.Language.Typechecker.Errors              (SagaError (..))
 import qualified Saga.Language.Typechecker.Refinement.Liquid   as L
 import           Saga.Language.Typechecker.Refinement.Liquid   (Liquid)

--- a/src/Saga/Language/Typechecker/Solver/Refinements.hs
+++ b/src/Saga/Language/Typechecker/Solver/Refinements.hs
@@ -54,7 +54,6 @@ data Refinement = Refine Scope Item Liquid deriving (Show)
 instance Entails Refinement where
     entails :: SolverEff es => Refinement -> [Constraint] -> Eff es [Constraint]
     entails ref@(Refine scope it liquid) cs = do
-        pTraceM "\n\n---------------------------------------\nEntailment Refinement:"
         implications <- Eff.liftIO $ forM refinements mkImplication
         let entailments = [ i | i@(SatResult (SBV.Unsatisfiable {})) <- implications ]
         if null entailments then
@@ -82,11 +81,8 @@ instance Solve Refinement where
     simplify = simplify'
 
 
--- | QUESTION: #30 Generate proofs/witnesses by leveraging the evidence system. This is how to identify that a certain type has been refined/narrowed
 solve' :: SolverEff es => Refinement -> Eff es (Status, Constraint)
 solve' r@(Refine scope it liquid) = do
-    pTraceM "\n\n---------------------------------------\nSolving Refinement:"
-    pTraceM $ show r
     res <- Eff.liftIO . SBV.sat $ evalStateT (translate liquid) empty
     case res of
         SatResult (SBV.Satisfiable _ model) -> return $
@@ -98,7 +94,6 @@ solve' r@(Refine scope it liquid) = do
 
 simplify' :: SolverEff es => Refinement -> Eff es  Constraint
 simplify' (Refine scope it liquid) = do
-    pTraceM "\n\n---------------------------------------\nSimplifying Refinement:"
     proofs' <- Eff.gets proofs
     let subst = scope ||> Map.mapWithKey (convert proofs')
     return $ Refined scope it (apply subst liquid)

--- a/src/Saga/Language/Typechecker/Solver/Run.hs
+++ b/src/Saga/Language/Typechecker/Solver/Run.hs
@@ -62,8 +62,11 @@ import           Saga.Language.Typechecker.Zonking.Zonking       (Context (..),
 
 run :: TypeCheck es => (Constraint, Levels) -> Eff es Context
 run (constraint, levels) = do
-    pTraceM $ "\nCONSTRAINTS:\n" ++ show constraint
+    pTraceM $ "\nCONSTRAINTS:\n" ++ show (Shared.flatten constraint)
     ((residuals, cycles), solution) <- Eff.runState initialSolution . Eff.evalState initialCount .  Eff.runState [] . Eff.runReader (Var.Level 0) . Eff.runReader levels $ process (Shared.flatten constraint) []
+    pTraceM $ "\n-----------------------------\nCYCLES:\n" ++ show cycles
+    pTraceM $ "\n-----------------------------\nRESIDUALS:\n" ++ show residuals
+    pTraceM $ "\n-----------------------------\nSOLUTION:\n" ++ show solution
     types <- foldM collapse (tvars solution) cycles
 
 

--- a/src/Saga/Language/Typechecker/Solver/Run.hs
+++ b/src/Saga/Language/Typechecker/Solver/Run.hs
@@ -62,7 +62,7 @@ import           Saga.Language.Typechecker.Zonking.Zonking       (Context (..),
 
 run :: TypeCheck es => (Constraint, Levels) -> Eff es Context
 run (constraint, levels) = do
-    pTraceM $ "\nCONTRAINTS:\n" ++ show constraint
+    pTraceM $ "\nCONSTRAINTS:\n" ++ show constraint
     ((residuals, cycles), solution) <- Eff.runState initialSolution . Eff.evalState initialCount .  Eff.runState [] . Eff.runReader (Var.Level 0) . Eff.runReader levels $ process (Shared.flatten constraint) []
     types <- foldM collapse (tvars solution) cycles
 

--- a/src/Saga/Language/Typechecker/Solver/Unification.hs
+++ b/src/Saga/Language/Typechecker/Solver/Unification.hs
@@ -75,7 +75,7 @@ class Substitutable t => Unification t where
 type TypeUnification es = UnificationEff es Type
 instance Unification Type where
     unify :: TypeUnification es => Type -> Type -> Eff es (Subst Type)
-    unify t t' | pTrace ("\nUnifying:\n" ++ show t ++ "\nWith:\n" ++ show t') False = undefined
+    --unify t t' | pTrace ("\nUnifying:\n" ++ show t ++ "\nWith:\n" ++ show t') False = undefined
     unify (T.Var v) t                                                   = bind v t
     unify t (T.Var v)                                                   = bind v t
     unify t@(T.Singleton a) t'@(T.Singleton b)  | a == b                = return nullSubst

--- a/src/Saga/Language/Typechecker/Solver/Unification.hs
+++ b/src/Saga/Language/Typechecker/Solver/Unification.hs
@@ -75,7 +75,7 @@ class Substitutable t => Unification t where
 type TypeUnification es = UnificationEff es Type
 instance Unification Type where
     unify :: TypeUnification es => Type -> Type -> Eff es (Subst Type)
-    --unify t t' | pTrace ("\nUnifying:\n" ++ show t ++ "\nWith:\n" ++ show t') False = undefined
+    unify t t' | pTrace ("\nUnifying:\n" ++ show t ++ "\nWith:\n" ++ show t') False = undefined
     unify (T.Var v) t                                               = bind v t
     unify t (T.Var v)                                               = bind v t
     unify (T.Singleton a) (T.Singleton b) | a == b                  = return nullSubst
@@ -175,7 +175,6 @@ instance Unification Type where
               T.Singleton lit -> Eff.tell $ Map.singleton a lit
               _               -> return ()
 
-            -- | TODO:ISSUE: #32 Generalize here?
             return . Map.singleton a $ case t of
                 T.Singleton (LInt _)    -> Lib.int
                 T.Singleton (LString _) -> Lib.string

--- a/src/Saga/Language/Typechecker/Solver/Unification.hs
+++ b/src/Saga/Language/Typechecker/Solver/Unification.hs
@@ -76,10 +76,12 @@ type TypeUnification es = UnificationEff es Type
 instance Unification Type where
     unify :: TypeUnification es => Type -> Type -> Eff es (Subst Type)
     unify t t' | pTrace ("\nUnifying:\n" ++ show t ++ "\nWith:\n" ++ show t') False = undefined
-    unify (T.Var v) t                                               = bind v t
-    unify t (T.Var v)                                               = bind v t
-    unify (T.Singleton a) (T.Singleton b) | a == b                  = return nullSubst
-    unify (T.Data con K.Type) (T.Data con' K.Type) | con == con'    = return nullSubst
+    unify (T.Var v) t                                                   = bind v t
+    unify t (T.Var v)                                                   = bind v t
+    unify t@(T.Singleton a) t'@(T.Singleton b)  | a == b                = return nullSubst
+                                                | otherwise             = throwError $ UnificationFail t t'
+    unify t@(T.Data con K.Type) t'@(T.Data con' K.Type) | con == con'   = return nullSubst
+                                                        | otherwise     = throwError $ UnificationFail t t'
 
     unify (T.Tuple as) (T.Tuple bs) = do
           ss <- zipWithM unify as bs
@@ -132,6 +134,7 @@ instance Unification Type where
           (t1, t2@(T.Closure {})) -> do
             Forall tvars (cs :=> t2') <- eval t2
             unify t1 t2'
+          _ -> crash $ NotYetImplemented $ "Unifying types: " ++ show t ++ " and " ++ show t'
 
         where
           kinds :: KindInference es => Eff es (Kind, Kind)


### PR DESCRIPTION
This PR fixes inference in case expressions by narrowing the scrutinee type to the matched pattern type.

There are still improvements to be made, namely properly dealing with variance in order to infer more specific return types and/or more general argument types.

